### PR TITLE
include_class is deprecated

### DIFF
--- a/skeleton/spec/classes/example_spec.rb.erb
+++ b/skeleton/spec/classes/example_spec.rb.erb
@@ -9,7 +9,7 @@ describe '<%= metadata.name %>' do
           :osfamily => osfamily,
         }}
 
-        it { should include_class('<%= metadata.name %>::params') }
+        it { should contain_class('<%= metadata.name %>::params') }
 
         it { should contain_class('<%= metadata.name %>::install') }
         it { should contain_class('<%= metadata.name %>::config') }


### PR DESCRIPTION
We should be using contain_class instead like what exists in the
rest of the example spec.
