### PR TITLE
Update Modulefile.erb

### DIFF
--- a/skeleton/Modulefile.erb
+++ b/skeleton/Modulefile.erb
@@ -1,5 +1,5 @@
 name          '<%= metadata.full_module_name %>'
-version       '0.0.1'
+version       '0.1.0'
 source        '<%= metadata.source %>'
 author        '<%= metadata.author %>'
 license       '<%= metadata.license %>'


### PR DESCRIPTION
Versions start at 0.1.0 as per semver.org. `puppet module build` also uses this as the starting version.
