### PR TITLE
Added new version of puppet/ruby to test against, and use https for rubygems

### DIFF
--- a/skeleton/.travis.yml
+++ b/skeleton/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
+  - 2.1.0
 script: bundle exec rake test
 env:
   - PUPPET_VERSION="~> 2.7.0"
@@ -13,11 +14,22 @@ env:
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.5.0"
 matrix:
   exclude:
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 2.7.0"
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 2.7.0"
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 3.1.0"
-  - rvm: 1.9.3
+  - rvm: 2.1.0
     env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.1.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.2.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.3.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.4.0"

--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 group :test do
   gem "rake"


### PR DESCRIPTION
Now that 3.5 is out, I would like to test against it. Also, Ruby 2.1.0 is supported.
I'm pretty sure I've got the matrix right that matches what Puppetlabs supports:
http://docs.puppetlabs.com/guides/platforms.html#ruby-versions

I always use your skeleton's .travis as a reference, as it is is always up to date, so I'm happy to PR to update it!

Also, https for rubygems for mitm protection?
