### PR TITLE
Now testing puppet 3.6, dropping 3.1

### DIFF
--- a/skeleton/.travis.yml
+++ b/skeleton/.travis.yml
@@ -10,23 +10,19 @@ rvm:
 script: bundle exec rake test
 env:
   - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.1.0"
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.5.0"
+  - PUPPET_VERSION="~> 3.6.0"
 matrix:
   exclude:
   - rvm: 1.9.3
     env: PUPPET_VERSION="~> 2.7.0"
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.1.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.1.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.2.0"
   - rvm: 2.1.0


### PR DESCRIPTION
At first I added 3.6, here is that matrix:
https://travis-ci.org/solarkennedy/puppet-bios/builds/29159096

I agree that it is getting pretty big.
The tricky thing about puppet, is that it is pretty prolific, as there is a lot of inertia against old platforms.
There are plenty of people and distros with ruby 1.8.7, still using puppet from their package manager.
http://docs.puppetlabs.com/guides/platforms.html#ruby-versions

So I made a conservative removal of 3.1, to keep the matrix size about the same with this PR
https://travis-ci.org/solarkennedy/puppet-bios/builds/29159640
