### PR TITLE
Create metadata.json.erb

### DIFF
--- a/skeleton/metadata.json.erb
+++ b/skeleton/metadata.json.erb
@@ -1,0 +1,18 @@
+{
+  "name": "<%= metadata.full_module_name %>",
+  "version": "0.1.0",
+  "source": "<%= metadata.source %>",
+  "author": "<%= metadata.author %>",
+  "license": "<%= metadata.license %>",
+  "summary": "<%= metadata.summary %>",
+  "description": "<%= defined?(metadata.description) ? metadata.description : metadata.summary %>",
+  "project_page": "<%= metadata.project_page %>",
+  "dependencies": [
+
+  ],
+  "types": [
+
+  ],
+  "checksums": {
+  }
+}


### PR DESCRIPTION
Modulefile has been deprecated as of Puppet 3.6
