### PR TITLE
Add equivalent to --relative arg to puppet-lint

### DIFF
--- a/skeleton/Rakefile
+++ b/skeleton/Rakefile
@@ -9,6 +9,7 @@ begin
 rescue LoadError
 end
 
+PuppetLint.configuration.relative = true
 PuppetLint.configuration.send("disable_80chars")
 PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.fail_on_warnings = true


### PR DESCRIPTION
Without this, testing a module called "bar" under a directory called
"foo-bar" fails the autoloader layout tests under puppet-lint 1.0

This is an issue because modules are often checked out as
<contributor>-<module>.
