### PR TITLE
Better checks for manifest application status

### DIFF
--- a/skeleton/spec/acceptance/class_spec.rb.erb
+++ b/skeleton/spec/acceptance/class_spec.rb.erb
@@ -4,14 +4,14 @@ describe '<%= metadata.name %> class' do
 
   context 'default parameters' do
     # Using puppet_apply as a helper
-    it 'should work with no errors' do
+    it 'should work idempotently with no errors' do
       pp = <<-EOS
       class { '<%= metadata.name %>': }
       EOS
 
       # Run it twice and test for idempotency
-      expect(apply_manifest(pp).exit_code).to_not eq(1)
-      expect(apply_manifest(pp).exit_code).to eq(0)
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes  => true)
     end
 
     describe package('<%= metadata.name %>') do


### PR DESCRIPTION
On trying these tests for the first time, starting a non-existent
service causes puppet to display errors, but still return 0 - thereby
generating a false positive in the test run.

I've adapted this template to use the catch_failures and catch_changes
options which I think is a better example to follow.
