### PR TITLE
Update metadata.json.erb

### DIFF
--- a/skeleton/metadata.json.erb
+++ b/skeleton/metadata.json.erb
@@ -1,18 +1,16 @@
 {
   "name": "<%= metadata.full_module_name %>",
-  "version": "0.1.0",
-  "source": "<%= metadata.source %>",
+  "version": "<%= metadata.version %>",
   "author": "<%= metadata.author %>",
-  "license": "<%= metadata.license %>",
   "summary": "<%= metadata.summary %>",
-  "description": "<%= defined?(metadata.description) ? metadata.description : metadata.summary %>",
+  "license": "<%= metadata.license %>",
+  "source": "<%= metadata.source %>",
   "project_page": "<%= metadata.project_page %>",
+  "issues_url": "<%= metadata.issues_url %>",
   "dependencies": [
-
-  ],
-  "types": [
-
-  ],
-  "checksums": {
-  }
+    {
+      "name": "puppetlabs-stdlib",
+      "version_range": ">= 1.0.0"
+    }
+  ]
 }


### PR DESCRIPTION
This file should meet the defaults by the "Generate boilerplate for new modules".

https://github.com/puppetlabs/puppet/blob/master/lib/puppet/face/module/generate.rb
- The user should be able to define the version
- The description was replaced by the summary
- The issues_url is based on the project_page
- And puppetlabs-stdlib seems to be a default dependency
