### PR TITLE
remove unneeded and unused vagrant-wrapper

### DIFF
--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -13,7 +13,6 @@ end
 group :development do
   gem "travis"
   gem "travis-lint"
-  gem "vagrant-wrapper"
   gem "puppet-blacksmith"
   gem "guard-rake"
 end


### PR DESCRIPTION
remove unneeded and unused vagrant-wrapper from Gemfile.
the way to fix the commonly occuring issue of vagrant (or beaker?) complaining about a missing (or outdated) vagrant-wrapper, is to *uninstall* it. from everywhere.