### PR TITLE
Also test things with strict_variables.

### DIFF
--- a/skeleton/.travis.yml
+++ b/skeleton/.travis.yml
@@ -10,11 +10,11 @@ rvm:
 script: bundle exec rake test
 env:
   - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.5.0"
-  - PUPPET_VERSION="~> 3.6.0"
+  - PUPPET_VERSION="~> 3.2.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.3.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.4.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
 matrix:
   exclude:
   - rvm: 1.9.3


### PR DESCRIPTION
strict_variables = true in puppet.conf is awesome, as it
stops you being able to typo variable names accidentally.

However, a lot of forge modules are not strict compliant.

Lets, by default test everything with strict variables true
as an option. I just _always_ set this, rather than multiply
the number of builds we run.
