### PR TITLE
Travis won't respect the matrix unless you pass the full env

### DIFF
--- a/skeleton/.travis.yml
+++ b/skeleton/.travis.yml
@@ -24,8 +24,8 @@ matrix:
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 2.7.0"
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0"
+    env: PUPPET_VERSION="~> 3.2.0" STRICT_VARIABLES=yes
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0"
+    env: PUPPET_VERSION="~> 3.3.0" STRICT_VARIABLES=yes
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.4.0"
+    env: PUPPET_VERSION="~> 3.4.0" STRICT_VARIABLES=yes


### PR DESCRIPTION
https://travis-ci.org/craigwatson/puppet-vmwaretools/builds/35996082

^^ Builds Puppet 3.2, 3.3 and 3.4 against Ruby 2.1.0 even though it's in the exclude matrix

https://travis-ci.org/craigwatson/puppet-vmwaretools/builds/35996295

^^ Respects the matrix and uses Ruby 2.0.0 for Puppet 3.2, 3.3 and 3.4
