### PR TITLE
ignore .bundle/ and vendor/ that come when using bundle install to install locally in an rbenv environment

### DIFF
--- a/skeleton/.gitignore
+++ b/skeleton/.gitignore
@@ -3,3 +3,5 @@ pkg
 spec/fixtures
 .rspec_system
 .vagrant
+.bundle
+vendor


### PR DESCRIPTION
When using rbenv to manage ruby version and running `bundle install` , locally inside the module dir, I get two new directories `.bundle/` and `vendor/` that should be added to the gitignore list.
