### PR TITLE
due to changes in puppet-lint 1.1.0 puppet-lint doesn't ignore the dirs set in `exclude-paths`

### DIFF
--- a/skeleton/Rakefile
+++ b/skeleton/Rakefile
@@ -25,6 +25,7 @@ exclude_paths = [
   "vendor/**/*",
   "spec/**/*",
 ]
+Rake::Task[:lint].clear
 PuppetLint.configuration.ignore_paths = exclude_paths
 PuppetSyntax.exclude_paths = exclude_paths
 


### PR DESCRIPTION
**The bug triggered by another bug:** :smile: 
Due to changes in the puppet-lint 1.1.0 rake configuration, the  exclude_paths array from `Rakefile` ( https://github.com/garethr/puppet-module-skeleton/blob/master/skeleton/Rakefile#L23 ) is ignored.
Breaking changes in puppet-lint in this issues: https://github.com/rodjek/puppet-lint/issues/331

**Fix:**
In the proposed pull request. Real fix coming when that puppet-lint bug will solved I guess.

**How to reproduce the bug:**
- Use the puppet-module-skeleton from the current latest commit aa26e72
- Create a new module.
- bundle install ( will create a `vendor/` dir locally to the module )
- run `bundle exec rake lint`:
  - with the fix in this pull request:
```bash
§ be rake lint
§
```
  - without the fix in this pull request `rake lint` tries to lint everything inside the `vendor/` dir:
```bash
§ be rake lint
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/boolean/manifests/init.pp:1:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/boolean/manifests/init.pp:8:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/cycle/manifests/bad.pp:1:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/cycle/manifests/good.pp:1:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/escape/manifests/def.pp:1:documentation:WARNING:defined type not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/escape/manifests/init.pp:1:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/escape/manifests/init.pp:3:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/relationships/manifests/before.pp:10:right_to_left_relationship:WARNING:right-to-left (<-) relationship
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/relationships/manifests/before.pp:1:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/relationships/manifests/notify.pp:1:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/structured_data/manifests/def.pp:1:documentation:WARNING:defined type not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/structured_data/manifests/def.pp:4:only_variable_string:WARNING:string containing only a variable
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/structured_data/manifests/def.pp:4:variables_not_enclosed:WARNING:variable not enclosed in {}
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/structured_data/manifests/init.pp:1:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/sysctl/manifests/init.pp:1:autoloader_layout:ERROR:sysctl::common not in autoload module layout
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/sysctl/manifests/init.pp:33:autoloader_layout:ERROR:sysctl::before not in autoload module layout
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/sysctl/manifests/init.pp:1:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/sysctl/manifests/init.pp:20:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/sysctl/manifests/init.pp:9:documentation:WARNING:defined type not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/sysctl/manifests/init.pp:33:documentation:WARNING:defined type not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/sysctl/manifests/init.pp:27:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/sysctl/manifests/init.pp:37:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/test/manifests/bare_class.pp:1:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/test/manifests/classes_used.pp:1:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/test/manifests/compile_error.pp:1:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/test/manifests/fail.pp:1:documentation:WARNING:class not documented
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/test/manifests/fail.pp:2:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/bundler/gems/rspec-puppet-28c29d09e472/spec/fixtures/modules/test/manifests/parameterised_class.pp:1:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/integration/node/environment/sitedir/00_a.pp:1:autoloader_layout:ERROR:a not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/integration/node/environment/sitedir/00_a.pp:1:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/integration/node/environment/sitedir/01_b.pp:1:autoloader_layout:ERROR:b not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/integration/node/environment/sitedir/01_b.pp:1:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/integration/node/environment/sitedir/04_include.pp:2:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/integration/node/environment/sitedir/04_include.pp:2:variables_not_enclosed:WARNING:variable not enclosed in {}
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/integration/node/environment/sitedir/04_include.pp:2:variables_not_enclosed:WARNING:variable not enclosed in {}
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/dev.pp:1:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/init.pp:24:variable_scope:WARNING:top-scope variable being used without an explicit namespace
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/init.pp:20:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/init.pp:21:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/init.pp:22:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/init.pp:29:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/init.pp:31:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/init.pp:32:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/init.pp:6:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/init.pp:10:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/params.pp:5:variable_scope:WARNING:top-scope variable being used without an explicit namespace
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/params.pp:5:case_without_default:WARNING:case statement without a default case
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/params.pp:1:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/params.pp:6:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/params.pp:11:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/params.pp:7:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/params.pp:8:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/params.pp:9:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/params.pp:12:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/params.pp:13:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/params.pp:14:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/php.pp:1:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp:5:variable_scope:WARNING:top-scope variable being used without an explicit namespace
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp:5:case_without_default:WARNING:case statement without a default case
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp:1:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp:6:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp:11:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp:12:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp:6:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp:8:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp:10:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp:11:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/ssl.pp:13:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/vhost.pp:1:parameter_order:WARNING:optional parameter listed before required parameter
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/vhost.pp:3:variable_scope:WARNING:top-scope variable being used without an explicit namespace
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/vhost.pp:1:documentation:WARNING:defined type not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/vhost.pp:9:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/vhost.pp:10:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/vhost.pp:11:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/vhost.pp:13:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/releases/jamtur01-apache/manifests/vhost.pp:11:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:1:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:2:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:6:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:7:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:9:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:12:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:13:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:15:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:2:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:7:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:8:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:13:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:14:arrow_alignment:WARNING:indentation of => is not properly aligned
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:3:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:8:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/aliastest.pp:14:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/append.pp:3:autoloader_layout:ERROR:arraytest not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/append.pp:4:variable_scope:WARNING:top-scope variable being used without an explicit namespace
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/append.pp:6:variable_scope:WARNING:top-scope variable being used without an explicit namespace
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/append.pp:3:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/append.pp:7:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/argumentdefaults.pp:3:autoloader_layout:ERROR:testargs not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/argumentdefaults.pp:7:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/argumentdefaults.pp:8:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/argumentdefaults.pp:11:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/argumentdefaults.pp:12:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/arithmetic_expression.pp:8:variables_not_enclosed:WARNING:variable not enclosed in {}
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/arraytrailingcomma.pp:2:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/arraytrailingcomma.pp:2:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/arraytrailingcomma.pp:2:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:5:case_without_default:WARNING:case statement without a default case
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:16:case_without_default:WARNING:case statement without a default case
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:21:case_without_default:WARNING:case statement without a default case
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:43:case_without_default:WARNING:case statement without a default case
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:3:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:6:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:7:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:9:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:10:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:14:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:17:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:18:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:20:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:20:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:22:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:23:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:25:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:26:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:33:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:34:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:37:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:45:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:54:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:55:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:56:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:60:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:62:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:62:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:64:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:7:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:10:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:18:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:23:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:26:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:34:2sp_soft_tabs:ERROR:two-space soft tabs not used
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:7:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:10:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:18:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:23:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:26:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:34:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:37:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:45:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:54:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:55:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:56:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:62:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:63:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:64:ensure_first_param:WARNING:ensure found on line but it's not the first attribute
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:7:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:10:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:18:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:23:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:26:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:34:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:37:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:45:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:54:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:55:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:56:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:62:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:63:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:64:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:7:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:10:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:18:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:23:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:26:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:34:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:37:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:45:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:54:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:55:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:56:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:62:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:63:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/casestatement.pp:64:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:3:autoloader_layout:ERROR:base not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:7:autoloader_layout:ERROR:sub1 not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:11:autoloader_layout:ERROR:sub2 not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:7:inherits_across_namespaces:WARNING:class inherits across module namespaces
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:11:inherits_across_namespaces:WARNING:class inherits across module namespaces
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:7:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:11:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:4:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:8:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:12:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:4:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:8:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:12:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:4:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:8:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classheirarchy.pp:12:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:3:autoloader_layout:ERROR:base not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:7:autoloader_layout:ERROR:sub1 not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:11:autoloader_layout:ERROR:sub2 not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:7:inherits_across_namespaces:WARNING:class inherits across module namespaces
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:11:inherits_across_namespaces:WARNING:class inherits across module namespaces
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:7:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:11:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:4:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:8:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:12:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:15:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:4:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:8:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:12:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:4:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:8:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classincludes.pp:12:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classpathtest.pp:7:autoloader_layout:ERROR:testing not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classpathtest.pp:3:autoloader_layout:ERROR:mytype not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classpathtest.pp:7:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classpathtest.pp:4:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classpathtest.pp:8:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classpathtest.pp:4:unquoted_file_mode:WARNING:unquoted file mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/classpathtest.pp:4:file_mode:WARNING:mode should be represented as a 4 digit octal value or symbolic mode
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection.pp:1:autoloader_layout:ERROR:one not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection.pp:6:autoloader_layout:ERROR:two not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection.pp:1:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection.pp:6:documentation:WARNING:class not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection.pp:2:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection.pp:2:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection.pp:3:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection.pp:3:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection.pp:7:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection_override.pp:2:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection_override.pp:3:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection_within_virtual_definitions.pp:1:autoloader_layout:ERROR:test not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection_within_virtual_definitions.pp:8:autoloader_layout:ERROR:test2 not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection_within_virtual_definitions.pp:1:documentation:WARNING:defined type not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection_within_virtual_definitions.pp:8:documentation:WARNING:defined type not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection_within_virtual_definitions.pp:15:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection_within_virtual_definitions.pp:16:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection_within_virtual_definitions.pp:18:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection_within_virtual_definitions.pp:2:variables_not_enclosed:WARNING:variable not enclosed in {}
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection_within_virtual_definitions.pp:3:variables_not_enclosed:WARNING:variable not enclosed in {}
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/collection_within_virtual_definitions.pp:9:variables_not_enclosed:WARNING:variable not enclosed in {}
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/componentmetaparams.pp:5:autoloader_layout:ERROR:thing not in autoload module layout
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/componentmetaparams.pp:5:documentation:WARNING:defined type not documented
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/componentmetaparams.pp:1:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/componentmetaparams.pp:9:double_quoted_strings:WARNING:double quoted string containing no variables
vendor/bundle/gems/puppet-3.6.2/spec/fixtures/unit/parser/lexer/componentmetaparams.pp:10:double_quoted_strings:WARNING:double quoted string containing no variables
rake aborted!
TypeError: no implicit conversion from nil to integer
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/plugins/check_whitespace.rb:115:in `[]'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/plugins/check_whitespace.rb:115:in `block (2 levels) in check'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/plugins/check_whitespace.rb:111:in `each'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/plugins/check_whitespace.rb:111:in `each_with_index'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/plugins/check_whitespace.rb:111:in `block in check'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/plugins/check_whitespace.rb:95:in `each'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/plugins/check_whitespace.rb:95:in `check'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/checkplugin.rb:21:in `run'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/checks.rb:58:in `block in run'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/checks.rb:56:in `each'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/checks.rb:56:in `run'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint.rb:168:in `run'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/tasks/puppet-lint.rb:72:in `block (3 levels) in define'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/tasks/puppet-lint.rb:70:in `each'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/tasks/puppet-lint.rb:70:in `block (2 levels) in define'
/media/truecrypt1/projects/pers/puppet/module-test-skeleton/stefan-testing/vendor/bundle/gems/puppet-lint-1.1.0/lib/puppet-lint/tasks/puppet-lint.rb:64:in `block in define'
Tasks: TOP => lint
(See full trace by running task with --trace)
```