### PR TITLE
be super pedantic about namepspacing to avoid confusion when using profiles

### DIFF
--- a/skeleton/manifests/init.pp.erb
+++ b/skeleton/manifests/init.pp.erb
@@ -8,14 +8,14 @@
 #   Explanation of what this parameter affects and what it defaults to.
 #
 class <%= metadata.name %> (
-  $package_name = $<%= metadata.name %>::params::package_name,
-  $service_name = $<%= metadata.name %>::params::service_name,
-) inherits <%= metadata.name %>::params {
+  $package_name = $::<%= metadata.name %>::params::package_name,
+  $service_name = $::<%= metadata.name %>::params::service_name,
+) inherits ::<%= metadata.name %>::params {
 
   # validate parameters here
 
-  class { '<%= metadata.name %>::install': } ->
-  class { '<%= metadata.name %>::config': } ~>
-  class { '<%= metadata.name %>::service': } ->
-  Class['<%= metadata.name %>']
+  class { '::<%= metadata.name %>::install': } ->
+  class { '::<%= metadata.name %>::config': } ~>
+  class { '::<%= metadata.name %>::service': } ->
+  Class['::<%= metadata.name %>']
 }

--- a/skeleton/manifests/install.pp.erb
+++ b/skeleton/manifests/install.pp.erb
@@ -2,7 +2,7 @@
 #
 class <%= metadata.name %>::install {
 
-  package { $<%= metadata.name %>::package_name:
+  package { $::<%= metadata.name %>::package_name:
     ensure => present,
   }
 }

--- a/skeleton/manifests/service.pp.erb
+++ b/skeleton/manifests/service.pp.erb
@@ -5,7 +5,7 @@
 #
 class <%= metadata.name %>::service {
 
-  service { $<%= metadata.name %>::service_name:
+  service { $::<%= metadata.name %>::service_name:
     ensure     => running,
     enable     => true,
     hasstatus  => true,

--- a/skeleton/tests/init.pp.erb
+++ b/skeleton/tests/init.pp.erb
@@ -9,4 +9,4 @@
 # Learn more about module testing here:
 # http://docs.puppetlabs.com/guides/tests_smoke.html
 #
-include <%= metadata.name %>
+include ::<%= metadata.name %>


### PR DESCRIPTION
Occasionally I've run into issues when using generated code for component-level modules from Profiles when I've not been very careful about resolution of class and variable names with explicit namespacing. It is rare but quite confusing when it does happen. I've made a couple of minor changes to the manifests skeleton files to use explicit namespacing. Pedantic mode on! ;)
