### PR TITLE
Make subs private

### DIFF
--- a/skeleton/manifests/config.pp.erb
+++ b/skeleton/manifests/config.pp.erb
@@ -3,4 +3,7 @@
 # This class is called from <%= metadata.name %> for service config.
 #
 class <%= metadata.name %>::config {
+
+  private("This class is private. Disallowed direct declaration from ${caller_module_name}.")
+
 }

--- a/skeleton/manifests/install.pp.erb
+++ b/skeleton/manifests/install.pp.erb
@@ -4,6 +4,8 @@
 #
 class <%= metadata.name %>::install {
 
+  private("This class is private. Disallowed direct declaration from ${caller_module_name}.")
+
   package { $::<%= metadata.name %>::package_name:
     ensure => present,
   }

--- a/skeleton/manifests/params.pp.erb
+++ b/skeleton/manifests/params.pp.erb
@@ -4,6 +4,7 @@
 # It sets variables according to platform.
 #
 class <%= metadata.name %>::params {
+
   case $::osfamily {
     'Debian': {
       $package_name = '<%= metadata.name %>'

--- a/skeleton/manifests/service.pp.erb
+++ b/skeleton/manifests/service.pp.erb
@@ -5,6 +5,8 @@
 #
 class <%= metadata.name %>::service {
 
+  private("This class is private. Disallowed direct declaration from ${caller_module_name}.")
+
   service { $::<%= metadata.name %>::service_name:
     ensure     => running,
     enable     => true,


### PR DESCRIPTION
Moved unless statements over to private() from stdlib.

Embedding private()s into sub-classes as an attempt to prevent people from instantiating sub-classes with include/require when they should probably include/require base implementation class and perhaps set up dependencies to the base class or perhaps the subclass.

Ex

``` puppet
# No!
class foo::service {
  require ::bar::service
}

# Better!
class foo::service {
  include ::bar
  Class[::bar::service] -> Class[::foo::service]
}
```
