### PR TITLE
Change stdlib url in .fixtures.yml.erb

### DIFF
--- a/skeleton/.fixtures.yml.erb
+++ b/skeleton/.fixtures.yml.erb
@@ -1,5 +1,5 @@
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     <%= metadata.name %>: "#{source_dir}"


### PR DESCRIPTION
Switched to the HTTP url for cloning puppet-stdlib. I know it a tiny bit slower, but it works behind an HTTP proxy so is more useful for many in a corporate environment
