### PR TITLE
Update Rakefile

### DIFF
--- a/skeleton/Rakefile
+++ b/skeleton/Rakefile
@@ -1,5 +1,6 @@
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet/vendor/semantic/lib/semantic'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
 


### PR DESCRIPTION
Update Rakefile to allow usage with Puppet Versions lower than 3.6.
metadata-json-lint has a dependency on semantic; which isn't in Puppet
versions lower than 3.6. This allows default skeleton of Rakefile
without having to change Rakefile based on puppet version