### PR TITLE
Stop travis tests failing on ruby 2.1.x

### DIFF
--- a/skeleton/.travis.yml
+++ b/skeleton/.travis.yml
@@ -25,3 +25,6 @@ matrix:
     env: PUPPET_VERSION="~> 2.7.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 2.7.0"
+    env: PUPPET_VERSION="~> 3.2.0"
+    env: PUPPET_VERSION="~> 3.3.0"
+    env: PUPPET_VERSION="~> 3.4.0"


### PR DESCRIPTION
Only puppet version >= 3.5 is supported on ruby 2.1.x. Adjust travis checks accordingly to avoid frozen symbol errors breaking tests.