### PR TITLE
Beaker updates

### DIFF
--- a/skeleton/spec/acceptance/class_spec.rb.erb
+++ b/skeleton/spec/acceptance/class_spec.rb.erb
@@ -3,15 +3,16 @@ require 'spec_helper_acceptance'
 describe '<%= metadata.name %> class' do
 
   context 'default parameters' do
-    # Using puppet_apply as a helper
-    it 'should work idempotently with no errors' do
-      pp = <<-EOS
-      class { '<%= metadata.name %>': }
-      EOS
+    pp = <<-EOS
+    class { '<%= metadata.name %>': }
+    EOS
 
-      # Run it twice and test for idempotency
-      apply_manifest(pp, :catch_failures => true)
+    it 'should work with no errors' do
       apply_manifest(pp, :catch_changes  => true)
+    end
+
+    it 'should be idempotent' do
+      apply_manifest(pp, :catch_failures => true)
     end
 
     describe package('<%= metadata.name %>') do

--- a/skeleton/spec/spec_helper_acceptance.rb.erb
+++ b/skeleton/spec/spec_helper_acceptance.rb.erb
@@ -21,9 +21,9 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.before :suite do
-    # Install module and dependencies
-    puppet_module_install(:source => proj_root, :module_name => '<%= metadata.name %>')
     hosts.each do |host|
+      # Install module and dependencies
+      copy_module_to(host, :source => proj_root, :module_name => '<%= metadata.name %>')
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
     end
   end


### PR DESCRIPTION
* Update to new beaker helper for installing module
* Move error and idempotent into separate tests
      - It's currently hard to see if the test is failing because it errored or it was not idempotent. This splits them out into separate contexts, so it's easier to read.
