### PR TITLE
Pin rspec to < 3.2.0

### DIFF
--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 group :test do
   gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
+  gem "rspec", '< 3.2.0'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"


### PR DESCRIPTION
Caused by Puppet monkey patches (rspec/rspec-core#1864)