### PR TITLE
Modify beaker env vars with consistent prefix and text case

### DIFF
--- a/skeleton/CONTRIBUTING.md
+++ b/skeleton/CONTRIBUTING.md
@@ -80,13 +80,13 @@ Beaker tests with:
     bundle exec rake acceptance
 
 This will use the host described in `spec/acceptance/nodeset/default.yml`
-by default. To run against another host, set the `RS_SET` environment
+by default. To run against another host, set the `BEAKER_set` environment
 variable to the name of a host described by a `.yml` file in the
 `nodeset` directory. For example, to run against CentOS 6.4:
 
-    RS_SET=centos-64-x64 bundle exec rake acceptance
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
 
 If you don't want to have to recreate the virtual machine every time you
-can use `BEAKER_DESTROY=no` and `BEAKER_PROVISION=no`. On the first run you will
-at least need `BEAKER_PROVISION` set to yes (the default). The Vagrantfile
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
 for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.


### PR DESCRIPTION
This matches the names used since at least beaker-rspec 2.2.0: https://github.com/puppetlabs/beaker-rspec/pull/24/files

