### PR TITLE
warn: making educated guesses in params / default

### DIFF
--- a/skeleton/manifests/params.pp.erb
+++ b/skeleton/manifests/params.pp.erb
@@ -14,7 +14,9 @@ class <%= metadata.name %>::params {
       $service_name = '<%= metadata.name %>'
     }
     default: {
-      fail("${::operatingsystem} not supported")
+      $package_name = '<%= metadata.name %>'
+      $service_name = '<%= metadata.name %>'
+      warn("${::operatingsystem} not fully supported")
     }
   }
 }


### PR DESCRIPTION
rather than flat-out failing on "unsupported OS'es" we try to take a smart guess,
but make no guarantees: hence, we `warn()`.