### PR TITLE
[Issue #75] Puppet-lint should report warnings.

### DIFF
--- a/skeleton/Rakefile
+++ b/skeleton/Rakefile
@@ -11,8 +11,6 @@ begin
 rescue LoadError
 end
 
-Rake::Task[:lint].clear
-
 PuppetLint.configuration.relative = true
 PuppetLint.configuration.send("disable_80chars")
 PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"


### PR DESCRIPTION
Currently:
  - rake tasks for lint do not report warnings.
  - rake tasks for lint always exit with 0 exit code.

By removing this line rake tasks will output warnings and
exit with the appriate error code.