### PR TITLE
specify puppet version for acceptance tests

### DIFF
--- a/skeleton/spec/spec_helper_acceptance.rb.erb
+++ b/skeleton/spec/spec_helper_acceptance.rb.erb
@@ -2,14 +2,7 @@ require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 
 unless ENV['BEAKER_provision'] == 'no'
-  hosts.each do |host|
-    # Install Puppet
-    if host.is_pe?
-      install_pe
-    else
-      install_puppet
-    end
-  end
+  install_puppet_on(hosts, { version: ENV['PUPPET_VERSION'] } )
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
This works for Puppet open source, including puppet 4.x. If no `$PUPPET_VERSION` is specified, it defaults to 3.8.x.

What about Puppet Enterprise?