### PR TITLE
Fix puppet version

### DIFF
--- a/skeleton/.travis.yml
+++ b/skeleton/.travis.yml
@@ -9,7 +9,6 @@ rvm:
   - 2.1.0
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
@@ -17,22 +16,14 @@ env:
   - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 4.2.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
 matrix:
   exclude:
-  # Ruby 1.9.3
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-    
-  # Ruby 2.0.0
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
-    
-  # Ruby 2.1.0
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.2.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.3.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.4.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"

--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :test do
   gem "rake"
-  gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 3.8.0'
+  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.0'
   gem "rspec", '< 3.2.0'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"


### PR DESCRIPTION
I've been using this skeleton for a long time, but I never double-checked the PUPPET_VERSION stuff.

Unless there is some other magic that is happening, I don't see how this ever worked? (setting the puppet version via travis)

So I think this is a bug, and I recently fixed it on this PR: https://github.com/Yelp/puppet-uchiwa/pull/55 and I wanted to send the fix upstream if you agree that this is a bug.

Additionally I cleaned up 2.7 support and added 4.2. If you want I can put that on a separate PR.