### PR TITLE
path where skeleton is stored adjusted

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ As we don't want to have our .git files and this README in our skeleton, we expo
 
     git clone https://github.com/garethr/puppet-module-skeleton
     cd puppet-module-skeleton
-    find skeleton -type f | git checkout-index --stdin --force --prefix="$HOME/.puppetlabs/var/puppet-module/" --
+    find skeleton -type f | git checkout-index --stdin --force --prefix="$HOME/.puppetlabs/opt/puppet/cache/puppet-module/" --
 
 ## the install.sh
 


### PR DESCRIPTION
Missed the fact that also the path inside ~/.puppetlabs is different between version 3 and 4.
