### PR TITLE
Restrict 'continuous-integration/travis-ci/push' activity to the master branch only as a default.

### DIFF
--- a/skeleton/.travis.yml
+++ b/skeleton/.travis.yml
@@ -2,6 +2,9 @@
 language: ruby
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
+branches:
+  only:
+    - master
 rvm:
   - 1.8.7
   - 1.9.3


### PR DESCRIPTION
'continuous-integration/travis-ci/pr' is unaffected. This prevents double-builds on PRs when both PRs and Pushes are enabled in the repo's Travis CI settings.