### PR TITLE
Add hiera to the default rspec setup

### DIFF
--- a/skeleton/.gitignore
+++ b/skeleton/.gitignore
@@ -1,6 +1,7 @@
 .*.sw?
 /pkg
-/spec/fixtures
+/spec/fixtures/manifests
+/spec/fixtures/modules
 /.rspec_system
 /.vagrant
 /.bundle

--- a/skeleton/spec/fixtures/hiera.yaml
+++ b/skeleton/spec/fixtures/hiera.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: './spec/fixtures/hieradata'
+:hierarchy:
+  - '%{::clientcert}'
+  - 'default'

--- a/skeleton/spec/fixtures/hieradata/default.yaml
+++ b/skeleton/spec/fixtures/hieradata/default.yaml
@@ -1,0 +1,2 @@
+---
+# Default key/value pairs

--- a/skeleton/spec/spec_helper.rb
+++ b/skeleton/spec/spec_helper.rb
@@ -14,3 +14,7 @@ SimpleCov.start do
     SimpleCov::Formatter::Console
   ])
 end
+
+RSpec.configure do |c|
+  c.hiera_config = File.expand_path(File.join(__FILE__, '../fixtures/hiera.yaml'))
+end


### PR DESCRIPTION
The skeleton's spec_helper will look at hiera data, if present, and enable automatic parameter lookup rather than requiring lengthy :params definition blocks.