### PR TITLE
Use container-based infrastructure instead of legacy infrastructure.

### DIFF
--- a/skeleton/.travis.yml
+++ b/skeleton/.travis.yml
@@ -1,4 +1,5 @@
 ---
+sudo: false
 language: ruby
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true


### PR DESCRIPTION
https://docs.travis-ci.com/user/workers/container-based-infrastructure/

Travis seems to be encouraging everyone to move to containers and are refreshing their legacy platforms, which leads to much slower builds as they're fiddling with the API thresholds (https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future). There also appear to be some problems with ruby 1.9.3 on the legacy platform (https://travis-ci.org/hunner/puppet-hiera/jobs/100710745).