### PR TITLE
Fix install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-install_dir=$(puppet apply --configprint module_working_dir)
+install_dir=$(puppet apply --configprint module_working_dir)/
 
 find skeleton -type f -not -name .gitkeep | git checkout-index --stdin --force --prefix=$install_dir


### PR DESCRIPTION
Skeleton was being deployed to
~/.puppetlabs/opt/puppet/cache/puppet-moduleskeleton and not being
picked up by puppet module generate.