### PR TITLE
Allow override of GEM_SOURCE

### DIFF
--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :test do
   gem "rake"


### PR DESCRIPTION
Allowing people who use internal gem sources to use their local GEM_SOURCE as option