### PR TITLE
strict reference checking using lint plugin

### DIFF
--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -19,6 +19,7 @@ group :test do
   gem "puppet-lint-classes_and_types_beginning_with_digits-check"
   gem "puppet-lint-unquoted_string-check"
   gem 'puppet-lint-resource_reference_syntax'
+  gem 'puppet-lint-reference_on_declaration_outside_of_class-check'
 end
 
 group :development do


### PR DESCRIPTION
the new lint extension checks for references to resource declarations
which are not local to a class.
to allow edge cases, where this behavior is explicitly needed the plugin
ony throws a warning instead of an error.