### PR TITLE
Update ruby dependencies, lessons learned from Vox Pupuli

### DIFF
--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -4,7 +4,7 @@ group :test do
   gem "rake"
   gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 3.8.0'
   gem "rspec", '< 3.2.0'
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem "rspec-puppet"
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "rspec-puppet-facts"
@@ -19,13 +19,15 @@ group :test do
   gem "puppet-lint-classes_and_types_beginning_with_digits-check"
   gem "puppet-lint-unquoted_string-check"
   gem 'puppet-lint-resource_reference_syntax'
+
+  gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
 end
 
 group :development do
-  gem "travis"
-  gem "travis-lint"
+  gem "travis"              if RUBY_VERSION >= '2.1.0'
+  gem "travis-lint"         if RUBY_VERSION >= '2.1.0'
   gem "puppet-blacksmith"
-  gem "guard-rake"
+  gem "guard-rake"          if RUBY_VERSION >= '2.2.5' # per dependency https://rubygems.org/gems/ruby_dep
 end
 
 group :system_tests do


### PR DESCRIPTION
As the march of End of Support goes on, many of the gems are no longer usable in certain versions of Ruby. This PR puts limits on the known issues so that users are able to proceed regardless of which ruby version they use.