### PR TITLE
Use coveralls in conjuction with simplecov

### DIFF
--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -9,8 +9,7 @@ group :test do
   gem "metadata-json-lint"
   gem "rspec-puppet-facts"
   gem 'rubocop', '0.33.0'
-  gem 'simplecov', '>= 0.11.0'
-  gem 'simplecov-console'
+  gem 'coveralls', :require => false if RUBY_VERSION >= '2.0.0'
 
   gem "puppet-lint-absolute_classname-check"
   gem "puppet-lint-leading_zero-check"

--- a/skeleton/spec/spec_helper.rb
+++ b/skeleton/spec/spec_helper.rb
@@ -4,15 +4,19 @@ require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
 require 'simplecov'
-require 'simplecov-console'
+unless RUBY_VERSION =~ %r{^1.9}
+  require 'coveralls'
+  Coveralls.wear!
+end
+
+SimpleCov.formatters = [
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
 
 SimpleCov.start do
   add_filter '/spec'
   add_filter '/vendor'
-  formatter SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::Console
-  ])
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
puppetlabs_spec_helper suggests [using coveralls](https://github.com/puppetlabs/puppetlabs_spec_helper#using-coveralls) which provides a [better readout](https://travis-ci.org/voxpupuli/puppet-jenkins_job_builder/jobs/172071888#L825-L838), IMO.