### PR TITLE
Remove semantic_puppet reference

### DIFF
--- a/skeleton/Rakefile
+++ b/skeleton/Rakefile
@@ -8,12 +8,6 @@ require 'puppet-syntax/tasks/puppet-syntax'
 require 'metadata-json-lint/rake_task'
 require 'rubocop/rake_task'
 
-if Puppet.version.to_f >= 4.9
-    require 'semantic_puppet'
-elsif Puppet.version.to_f >= 3.6 && Puppet.version.to_f < 4.9
-    require 'puppet/vendor/semantic/lib/semantic'
-end
-
 # These gems aren't always present, for instance
 # on Travis with --without development
 begin


### PR DESCRIPTION
This dates to when the metadata_lint test was a shell script. I removed it in my modules with no problems, see https://github.com/rnelson0/puppet-certs/pull/30 and https://travis-ci.org/rnelson0/puppet-certs/builds/197288482