### PR TITLE
fix missing requirement

### DIFF
--- a/skeleton/spec/classes/coverage_spec.rb
+++ b/skeleton/spec/classes/coverage_spec.rb
@@ -1,1 +1,3 @@
+require 'spec_helper'
+
 at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
Coverage spec should require `spec_helper`, so that constant `RSpec::Puppet` will be defined:

```
core.rb:166:in `block in const_missing': uninitialized constant RSpec::Puppet (NameError)
        from rspec-core-3.1.7/lib/rspec/core.rb:166:in `fetch'
        from rspec-core-3.1.7/lib/rspec/core.rb:166:in `const_missing'
```